### PR TITLE
Export Stream as Target...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,16 +16,6 @@ include(GNUInstallDirs)
 set(CMAKE_INSTALL_CMAKEDIR ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 set(STREAM_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/stream)
 
-export(
-  TARGETS ${PROJECT_TARGETS}
-  NAMESPACE stream::
-  FILE ${PROJECT_NAME}Targets.cmake)
-
-install(
-  EXPORT ${PROJECT_NAME}Targets
-  NAMESPACE stream::
-  DESTINATION ${CMAKE_INSTALL_CMAKEDIR})
-
 #--- Load some basic macros ---
 include(StreamMacros)
 
@@ -53,8 +43,13 @@ else()
   set(_ldvname_ LD_LIBRARY_PATH)
 endif()
 
-configure_file(${CMAKE_SOURCE_DIR}/cmake/scripts/StreamConfig.cmake.in
-               ${CMAKE_BINARY_DIR}/StreamConfig.cmake COPYONLY)
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+  ${CMAKE_SOURCE_DIR}/cmake/scripts/StreamConfig.cmake.in
+  ${CMAKE_BINARY_DIR}/StreamConfig.cmake
+  INSTALL_DESTINATION lib/cmake/Stream
+)
 
 set(_streamsys_ ${CMAKE_BINARY_DIR})
 set(_streaminc_ ${CMAKE_BINARY_DIR}/include)
@@ -73,6 +68,10 @@ configure_file(${CMAKE_SOURCE_DIR}/cmake/scripts/streamlogin.in
 install(PROGRAMS ${PROJECT_BINARY_DIR}/macros/streamlogin
         DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+install(FILES ${CMAKE_BINARY_DIR}/StreamConfig.cmake
+        DESTINATION ${CMAKE_INSTALL_CMAKEDIR}
+)
+
 add_subdirectory(framework)
 
 if(Go4_FOUND)
@@ -81,3 +80,14 @@ endif()
 
 get_property(__allHeaders GLOBAL PROPERTY STREAM_HEADER_TARGETS)
 add_custom_target(move_headers ALL DEPENDS ${__allHeaders})
+
+export(
+  EXPORT ${PROJECT_NAME}Targets
+  NAMESPACE stream::
+  FILE ${PROJECT_NAME}Targets.cmake)
+
+install(
+  EXPORT ${PROJECT_NAME}Targets
+  NAMESPACE stream::
+  DESTINATION ${CMAKE_INSTALL_CMAKEDIR})
+

--- a/cmake/modules/StreamMacros.cmake
+++ b/cmake/modules/StreamMacros.cmake
@@ -70,7 +70,11 @@ function(STREAM_LINK_LIBRARY libname)
 
    # add_dependencies(${libname} move_headers ${ARG_DEPENDENCIES})
 
-   target_include_directories(${libname} PRIVATE ${CMAKE_SOURCE_DIR}/include)
+   target_include_directories(${libname}
+      PUBLIC
+         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:${STREAM_INSTALL_INCLUDEDIR}>
+   )
 
    install(
     TARGETS ${libname}

--- a/cmake/scripts/StreamConfig.cmake.in
+++ b/cmake/scripts/StreamConfig.cmake.in
@@ -1,15 +1,5 @@
-# Stream CMake Configuration File for External Projects
+@PACKAGE_INIT@
 
-# Stream configured for use from the build tree - absolute paths are used.
-set(STREAM_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/include)
+include(CMakeFindDependencyMacro)
 
-# Stream configured for use from the build tree - absolute paths are used.
-set(STREAM_LIBRARY_DIR ${CMAKE_CURRENT_LIST_DIR}/lib)
-
-# search for stream libraries
-foreach(_cpt Stream)
-  find_library(${_cpt}_LIBRARY ${_cpt} HINTS ${STREAM_LIBRARY_DIR})
-  if(${_cpt}_LIBRARY)
-    mark_as_advanced(${_cpt}_LIBRARY)
-  endif()
-endforeach()
+include("${CMAKE_CURRENT_LIST_DIR}/StreamTargets.cmake")

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -137,7 +137,7 @@ STREAM_LINK_LIBRARY(Stream
 
 # ================== Install Stream headers ==========
 
-foreach(dir base dogma get4 hadaq mbs nx)
+foreach(dir base dogma get4 hadaq mbs nx dabc)
    install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/${dir}
           DESTINATION ${STREAM_INSTALL_INCLUDEDIR})
 endforeach()

--- a/go4engine/CMakeLists.txt
+++ b/go4engine/CMakeLists.txt
@@ -28,3 +28,6 @@ install(
 
 install(FILES ${CMAKE_BINARY_DIR}/lib/libGo4UserAnalysis.rootmap ${CMAKE_BINARY_DIR}/lib/libGo4UserAnalysis_rdict.pcm
         DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(FILES TStreamEvent.h TUserSource.h TFirstStepProcessor.h
+        DESTINATION ${STREAM_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
... instead of setting the STREAM_Library, etc. variables manually.

The second commit installs missing headers into to install prefix.

The corresponding PR for DABC follows.