### PR TITLE
Allow Framework and Go4Engine to be built separately.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,22 +72,28 @@ install(FILES ${CMAKE_BINARY_DIR}/StreamConfig.cmake
         DESTINATION ${CMAKE_INSTALL_CMAKEDIR}
 )
 
-add_subdirectory(framework)
+option(ENABLE_FRAMEWORK "Build framework subdirectory" ON)
+option(ENABLE_GO4ENGINE "Build go4engine subdirectory" ON)
 
-if(Go4_FOUND)
-   add_subdirectory(go4engine)
+if(ENABLE_FRAMEWORK)
+  add_subdirectory(framework)
+endif()
+
+if(ENABLE_GO4ENGINE AND Go4_FOUND)
+  add_subdirectory(go4engine)
 endif()
 
 get_property(__allHeaders GLOBAL PROPERTY STREAM_HEADER_TARGETS)
 add_custom_target(move_headers ALL DEPENDS ${__allHeaders})
 
-export(
-  EXPORT ${PROJECT_NAME}Targets
-  NAMESPACE stream::
-  FILE ${PROJECT_NAME}Targets.cmake)
+if(ENABLE_FRAMEWORK)
+  export(
+    EXPORT ${PROJECT_NAME}Targets
+    NAMESPACE stream::
+    FILE ${PROJECT_NAME}Targets.cmake)
 
-install(
-  EXPORT ${PROJECT_NAME}Targets
-  NAMESPACE stream::
-  DESTINATION ${CMAKE_INSTALL_CMAKEDIR})
-
+  install(
+    EXPORT ${PROJECT_NAME}Targets
+    NAMESPACE stream::
+    DESTINATION ${CMAKE_INSTALL_CMAKEDIR})
+endif()

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -135,6 +135,8 @@ STREAM_LINK_LIBRARY(Stream
    LIBRARIES ${stream_libs}
 )
 
+add_library(stream::Stream ALIAS Stream)
+
 # ================== Install Stream headers ==========
 
 foreach(dir base dogma get4 hadaq mbs nx dabc)
@@ -175,4 +177,5 @@ if(ROOT_FOUND)
    install(FILES ${CMAKE_BINARY_DIR}/lib/libStreamDict.rootmap ${CMAKE_BINARY_DIR}/lib/libStreamDict_rdict.pcm
            DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
+   add_library(stream::StreamDict ALIAS StreamDict)
 endif()

--- a/go4engine/CMakeLists.txt
+++ b/go4engine/CMakeLists.txt
@@ -1,5 +1,9 @@
 include(${GO4_USE_FILE})
 
+if(NOT TARGET stream::Stream)
+   find_package(Stream REQUIRED PATHS $ENV{STREAMSYS})
+endif()
+
 GO4_USER_ANALYSIS(
    LINKDEF
       LinkDef.h
@@ -11,7 +15,7 @@ GO4_USER_ANALYSIS(
       TUserSource.cxx
       TFirstStepProcessor.cxx
    LIBRARIES
-      Stream StreamDict
+      stream::Stream stream::StreamDict
    INCLUDE_DIRS
       ${CMAKE_SOURCE_DIR}/include
    TARGET_DIR


### PR DESCRIPTION
This PR allows to build the GO4 Plugin and the Framework separately. This allows to model dependencies more flexibile. The NIX flake will then have two Deriviations: stream.framework and stream.go4engine. Only stream.go4engine will depend on Go4.

---

* Use -DENABLE_FRAMEWORK=OFF -DENABLE_GO4ENGINE=ON to build only go4engine
* Use -DENABLE_FRAMEWORK=ON -DENABLE_GO4ENGINE=OFF to build only framework
* default is both ON

---

* create alias targets stream::Stream and stream::StreamDict
* use find_package(Stream) in go4engine to make sure that it can build separately (if it's build internally, then the aliases apply)